### PR TITLE
fix: `cargo install espup` without `--locked`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 这里是 https://github.com/esp-rs/book 的简体中文翻译。[直接在网页中阅读](https://narukara.github.io/rust-on-esp-book-zh-cn/)
 
-目前进度：已经翻译完成（部分更新的内容需要重新翻译），跟踪到 b9c2968
+目前进度：已经翻译完成（部分更新的内容需要重新翻译），跟踪到 8011021
 
 ---
 

--- a/src/installation/riscv-and-xtensa.md
+++ b/src/installation/riscv-and-xtensa.md
@@ -6,7 +6,7 @@
 
 要安装 `espup`，执行：
 ```shell
-cargo install espup
+cargo install espup --locked
 ```
 
 也可以直接下载预编译好的[发行二进制文件][release-binaries]或使用[`cargo-binstall`][cargo-binstall]。


### PR DESCRIPTION
This pull request makes a minor update to the installation instructions for `espup` in the `src/installation/riscv-and-xtensa.md` file. The change improves installation reliability by adding the `--locked` flag to the `cargo install` command.

* Added the `--locked` flag to the `cargo install espup` command to ensure dependency versions are strictly respected during installation.
* #7 